### PR TITLE
rotateAsync fixes

### DIFF
--- a/src/stepperbase.h
+++ b/src/stepperbase.h
@@ -79,17 +79,19 @@ namespace TS4
         s += 1;
         pos += dir;
 
-        StepperBase* stepper = next;
-        while (stepper != nullptr) // move slave motors if required
-        {
-            if (stepper->B >= 0)
+        if (mode == mode_t::target) {
+            StepperBase* stepper = next;
+            while (stepper != nullptr) // move slave motors if required
             {
-                digitalWriteFast(stepper->stepPin, HIGH);
-                stepper->pos += stepper->dir;
-                stepper->B -= this->A;
+                if (stepper->B >= 0)
+                {
+                    digitalWriteFast(stepper->stepPin, HIGH);
+                    stepper->pos += stepper->dir;
+                    stepper->B -= this->A;
+                }
+                stepper->B += stepper->A;
+                stepper = stepper->next;
             }
-            stepper->B += stepper->A;
-            stepper = stepper->next;
         }
     }
 
@@ -123,6 +125,7 @@ namespace TS4
 
     void StepperBase::rotISR()
     {
+        mode = mode_t::rotate;
         int32_t v_abs;
 
         if (std::abs(v_sqr - v_tgt_sqr) > twoA) // target speed not yet reached
@@ -134,12 +137,12 @@ namespace TS4
             delayMicroseconds(5);
 
             v_abs = sqrtf(std::abs(v_sqr));
-             SerialUSB.printf("vabs % d\n",v_abs);
+            //SerialUSB.printf("vabs % d\n",v_abs);
             stpTimer->updateFrequency(v_abs);
             doStep();
         } else
         {
-            SerialUSB.println("rotISR reached");
+            //SerialUSB.println("rotISR reached");
             dir = signum(v_sqr);
             digitalWriteFast(dirPin, dir > 0 ? HIGH : LOW);
             delayMicroseconds(5);
@@ -147,17 +150,19 @@ namespace TS4
             if (v_tgt != 0)
             {
                 v_abs = sqrtf(std::abs(v_sqr));
-                SerialUSB.printf("vabs % d\n",v_abs);
+                //SerialUSB.printf("vabs % d\n",v_abs);
                 stpTimer->updateFrequency(v_abs);
                 doStep();
             } else
             {
-                SerialUSB.printf("rotISR %s stopped\n", name.c_str());
+                //SerialUSB.printf("rotISR %s stopped\n", name.c_str());
                 stpTimer->stop();
                 TimerFactory::returnTimer(stpTimer);
                 stpTimer = nullptr;
                 isMoving = false;
                 v_sqr = 0;
+                
+                mode = mode_t::target;
             }
         }
 

--- a/src/timers/Teensy4/TMR/TMR.h
+++ b/src/timers/Teensy4/TMR/TMR.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../../interfaces.h"
-#include "arduino.h"
+#include "Arduino.h"
 #include "imxrt.h"
 
 namespace TS4
@@ -103,7 +103,7 @@ namespace TS4
     {
         constexpr unsigned prescale = 32;
         period                      = (150E6 / prescale) / f - pulsewidth - 1.5f;
-        Serial.printf("p: %d\n", period);
+        //Serial.printf("p: %d\n", period);
 
         //constexpr uint16_t pp = p;
     }


### PR DESCRIPTION
Fixes rotateAsync after 'group move'.
When running "doStep()", checks that the current mode is 'target' before doing steps across all motors.

Fixes overrideSpeed for rapid -ve and +ve moves.
While running "rotISR()" keep mode as 'rotate' otherwise upon moving quickly from -ve to +ve, through zero and therefore mode = 'stopping', rotateAsync doesn't have time to change mode from 'stopping' to 'rotate' again. This meant that "overrideSpeed" wasn't run as it's "if (mode == mode_t::rotate)" statement wasn't running.