### PR TITLE
Initialize pos to 0 in StepperBase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vsteensy/**
 .vscode/**
 makefile
+.pio
 
 # dependency files
 *.d

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # TeensyStep4
 
 Please note: This library is very experimental and no support can be given at the moment. 
+
+## Running unit tests ##
+```
+pio test
+```

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,16 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:teensy41]
+platform = teensy
+board = teensy41
+framework = arduino
+upload_protocol = teensy-cli
+test_build_src = yes

--- a/src/stepperbase.h
+++ b/src/stepperbase.h
@@ -33,7 +33,7 @@ namespace TS4
         int32_t dir;
         int32_t vDir;
 
-        volatile int32_t pos;
+        volatile int32_t pos = 0;
         volatile int32_t target;
 
         int32_t s_tgt;

--- a/test/test_stepper.cpp
+++ b/test/test_stepper.cpp
@@ -1,0 +1,15 @@
+#include <unity.h>
+
+#include "teensystep4.h"
+
+void test_pos_initialized() {
+    TS4::Stepper stepper(/*stepPin*/ 0, /*dirPin*/ 1);
+    
+    TEST_ASSERT_EQUAL_INT(0, stepper.getPosition());
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_pos_initialized);
+    return UNITY_END();
+}


### PR DESCRIPTION
The `pos` variable in the Stepper class was not initialized. This caused it to get a random value if the object is allocated on the stack or heap.

Fixes #14 